### PR TITLE
[FEAT] generate random image url from folder using resourcefactory

### DIFF
--- a/Classes/Services/FolderService.php
+++ b/Classes/Services/FolderService.php
@@ -14,6 +14,7 @@ namespace SvenJuergens\BeloginImages\Services;
  *
  * The TYPO3 project - inspiring people to share!
  */
+use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class FolderService
@@ -37,8 +38,10 @@ class FolderService
                 // Pick random file:
                 mt_srand((int)((float)microtime() * 10000000));
                 $rand = array_rand($files, 1);
+
+                $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
                 $imageData = [
-                    'url' => '/' . htmlspecialchars($settings['folder']) . $files[$rand]
+                    'url' => $resourceFactory->getFileObjectFromCombinedIdentifier($settings['folder'] . '/' . $files[$rand])->getPublicUrl()
                 ];
             }
         }


### PR DESCRIPTION
Hej there,

We're using belogin_images within a project context, where a staging server with multiple TYPO3 instances exists, accessing them through a sub path in the domain, e.g. typo3-stage.domain.com/feature-xyz/.
Unfortunately the absolute path of the image url from the FolderService doesn't work for this scenario, so I provided a fix to generate the necessary public url. 